### PR TITLE
feat(config): add default_folder setting to open the menu in a chosen directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,8 @@ jobs:
           cp apploader.img         dist/swiss/patches/apploader.img
           cp cubiboot.iso          dist/cubiboot.iso
           # config.ini (byte-exact, no trailing newline)
-          printf '[cubeboot]\n\nmenu_grid_type = small_banners' > dist/config.ini
+          # default_folder ships commented out so the menu opens at the SD root by default.
+          printf '[cubeboot]\n\nmenu_grid_type = small_banners\n\n; Folder the menu opens in at startup. Leave commented for the SD card root.\n; default_folder = /games' > dist/config.ini
           # EXTRACT_TO_ROOT.zip: extract to the SD card root (ipl.dol + config.ini + apploader.img)
           (cd dist && zip -r ../EXTRACT_TO_ROOT.zip ipl.dol config.ini swiss)
           cp EXTRACT_TO_ROOT.zip dist/EXTRACT_TO_ROOT.zip

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ optional):
 commented) to open the SD card root. A leading `/` is added automatically if you omit
 it, and if the folder can't be opened cubiboot falls back to the root.
 
+> **Note:** `default_folder` only changes where the menu browses for **games and
+> homebrew** (`.dol`/`.dol.gz`/`.iso`/etc.) — those can live in a subfolder. The
+> system files must still sit at the **SD card root**: `ipl.dol`, `config.ini`, and
+> `swiss/patches/apploader.img`.
+
 ```ini
 [cubeboot]
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ optional):
 | `banners` | large banners, 3 columns |
 | `square_icons` | square icons, 8 columns |
 
+`default_folder` sets the directory the menu opens in at startup. Leave it unset (or
+commented) to open the SD card root. A leading `/` is added automatically if you omit
+it, and if the folder can't be opened cubiboot falls back to the root.
+
 ```ini
 [cubeboot]
 
@@ -85,6 +89,9 @@ optional):
 ;   banners       = large banners, 3 columns
 ;   square_icons  = square icons, 8 columns
 menu_grid_type = small_banners
+
+; Folder the menu opens in at startup. Leave commented for the SD card root.
+; default_folder = /games
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -140,4 +140,5 @@ This project stands on the work of others — the items below are **not** origin
 - [PicoLoader](https://github.com/makeo/PicoLoader) by [makeo](https://github.com/makeo) — the RP2040 ODE the `.uf2` targets. (GPL-2.0)
 - [apploader / cubeboot-tools](https://github.com/makeo/cubeboot-tools) (GPL-2.0)
 - [packer](https://github.com/emukidid/swiss-gc/tree/master/cube/packer) (from Swiss) — used to build `apploader.img`. (GPL-2.0)
+- The **`default_folder`** config option by [wins1ey](https://github.com/wins1ey), via the [Hazado/cubiboot](https://github.com/Hazado/cubiboot) fork ([merge](https://github.com/Hazado/cubiboot/commit/c91066b4889346fec288393f6a9fe41304652e49)) — ported into this fork. (GPL-2.0)
 - For the full breakdown, see upstream [CREDIT.md](https://github.com/makeo/cubiboot/blob/main/CREDIT.md).

--- a/cubeboot/source/main.c
+++ b/cubeboot/source/main.c
@@ -318,6 +318,13 @@ int main(int argc, char **argv) {
     //     strcpy(cube_logo_ptr, settings.cube_logo);
     // }
 
+    // Copy default folder string into the patch
+    void *default_folder_ptr = (void*)get_symbol_value(symshdr, syment, symstringdata, "default_folder");
+    if (default_folder_ptr != NULL && settings.default_folder != NULL) {
+        iprintf("Copying default_folder: %p\n", default_folder_ptr);
+        strcpy(default_folder_ptr, settings.default_folder);
+    }
+
     // Copy other variables
     set_patch_value(symshdr, syment, symstringdata, "is_running_dolphin", is_running_dolphin);
 

--- a/cubeboot/source/settings.c
+++ b/cubeboot/source/settings.c
@@ -73,6 +73,13 @@ void load_settings() {
         settings.cube_logo = (char*)cube_logo;
     }
 
+    // default folder
+    const char *default_folder = ini_get(conf, "cubeboot", "default_folder");
+    if (default_folder != NULL) {
+        iprintf("Found default_folder = %s\n", default_folder);
+        settings.default_folder = (char*)default_folder;
+    }
+
     // default program
     const char *default_program = ini_get(conf, "cubeboot", "default_program");
     if (default_program != NULL) {

--- a/cubeboot/source/settings.h
+++ b/cubeboot/source/settings.h
@@ -6,6 +6,7 @@
 typedef struct settings {
     u32 cube_color;
     char *cube_logo;
+    char *default_folder;
     u32 force_swiss_default;
     u32 show_watermark;
     u32 disable_mcp_select;

--- a/patches/source/main.c
+++ b/patches/source/main.c
@@ -45,6 +45,7 @@ __attribute_data__ u32 start_passthrough_game = 0;
 
 __attribute_data__ static u8 *cube_text_tex = NULL;
 __attribute_data__ char cube_logo_path[MAX_FILE_NAME] = {0};
+__attribute_data__ char default_folder[MAX_FILE_NAME] = {0};
 __attribute_data__ u32 force_progressive = 0;
 __attribute_data__ u32 force_swiss_boot = 0;
 
@@ -347,6 +348,31 @@ __attribute_used__ void mod_cube_anim() {
     }
 }
 
+// Resolve the configured default folder into a path the menu can open.
+// Falls back to the SD root ("/") when unset or when the folder can't be opened.
+__attribute_used__ char* resolve_default_folder() {
+    if (default_folder[0] == '\0') {
+        OSReport("No default folder set, opening root\n");
+        return "/";
+    }
+
+    const char *path = default_folder;
+    static char path_buf[MAX_FILE_NAME];
+    if (default_folder[0] != '/') {
+        snprintf(path_buf, sizeof(path_buf), "/%s", default_folder);
+        path = path_buf;
+    }
+
+    if (dvd_custom_open(path, FILE_ENTRY_TYPE_DIR, 0) != 0) {
+        OSReport("Could not open default folder: %s, opening root\n", path);
+        return "/";
+    }
+    dvd_custom_close(dvd_custom_status()->fd);
+
+    OSReport("Using default folder: %s\n", path);
+    return (char*)path;
+}
+
 __attribute_used__ void pre_thread_init() {
     dolphin_ARAMInit();
     orig_thread_init();
@@ -354,7 +380,7 @@ __attribute_used__ void pre_thread_init() {
     gm_init_heap();
     gm_init_thread();
     if (!start_passthrough_game) {
-        gm_start_thread("/");
+        gm_start_thread(resolve_default_folder());
     }
 }
 


### PR DESCRIPTION
## What

Ports the **default folder** feature into this fork. A new `default_folder` key in `config.ini` lets the game menu open in a chosen directory instead of always starting at the SD card root.

**Credit:** the feature was authored by [@wins1ey](https://github.com/wins1ey) and merged into the [Hazado/cubiboot](https://github.com/Hazado/cubiboot) fork ([merge c91066b](https://github.com/Hazado/cubiboot/commit/c91066b4889346fec288393f6a9fe41304652e49)). This PR merely ports their work here; full attribution is added to the README credits.

```ini
[cubeboot]
default_folder = /games   ; leading "/" auto-added; bad/missing path falls back to root
```

## How it works

cubiboot runs in two halves that communicate through named ELF symbols. The loader (`cubeboot/`) reads `config.ini` and copies values into the injected patch code (`patches/`). The menu's directory browser is driven entirely by the string passed to `gm_start_thread()` — previously hardcoded to `"/"`.

- **settings.{c,h}** — parse `default_folder` from `[cubeboot]`
- **cubeboot/source/main.c** — `strcpy` the string into the patch's `default_folder` symbol (same pattern as the existing `cube_logo_path` copy)
- **patches/source/main.c** — add the `default_folder[]` buffer + `resolve_default_folder()` (prepends a leading `/`, validates the dir via `dvd_custom_open`, falls back to `"/"` if unset or unopenable), and feed it to `gm_start_thread()`

## Scope

`default_folder` only changes where the menu browses for **games and homebrew** — those can live in a subfolder. The **system files must stay at the SD card root**: `ipl.dol`, `config.ini`, and `swiss/patches/apploader.img`.

## Release default stays root

- **ci.yml** — the shipped `config.ini` documents the option but ships it **commented out**, so out-of-the-box behaviour is unchanged (menu opens at SD root).
- **README** — documents the setting, the scope note above, and credits @wins1ey under Configuration / Credits.

## Verification

- Builds clean via the local Docker/devkitPPC toolchain: `make clean && make` → `dist/IPL.dol` = 670464 bytes (~670 KB, the functional baseline). Patches ELF + loader DOL both rebuilt.
- CI builds the branch and produces artifacts.
- Tested on real hardware by the maintainer (@DarthMotzkus) — works as expected.

Co-Authored-By: wins1ey <wins1ey@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
