### PR TITLE
feat(menu): per-disc banners & names + instant cold boot (Lever A)

### DIFF
--- a/cubeboot/source/emu/tweaks.c
+++ b/cubeboot/source/emu/tweaks.c
@@ -115,6 +115,11 @@ void bnr_cache_load(BNR* bnr, u32 aram_offset) {
 
 typedef struct {
     u8 game_id[6];
+    // Multi-disc games share the same game_id (game code + maker code); only the disc
+    // number (header 0x06) and version differ. Key on the full disc identity so disc 2+
+    // gets its own banner/description instead of aliasing disc 1's cached entry.
+    u8 disc_num;
+    u8 disc_ver;
     u32 aram_offset;
     bool valid;
 } bnr_cache_entry_t;
@@ -122,20 +127,27 @@ typedef struct {
 static bnr_cache_entry_t bnr_cache[BNR_CACHE_SIZE] = {0};
 static u32 bnr_cache_next_index = 0;
 
-bool bnr_cache_get(u8 game_id[6], BNR* bnr) {
+static inline bool bnr_cache_entry_matches(const bnr_cache_entry_t* e, u8 game_id[6], u8 disc_num, u8 disc_ver) {
+    return e->valid
+        && memcmp(e->game_id, game_id, 6) == 0
+        && e->disc_num == disc_num
+        && e->disc_ver == disc_ver;
+}
+
+bool bnr_cache_get(u8 game_id[6], u8 disc_num, u8 disc_ver, BNR* bnr) {
     for (int i = 0; i < BNR_CACHE_SIZE; i++) {
-        if (bnr_cache[i].valid && memcmp(bnr_cache[i].game_id, game_id, 6) == 0) {
+        if (bnr_cache_entry_matches(&bnr_cache[i], game_id, disc_num, disc_ver)) {
             bnr_cache_load(bnr, bnr_cache[i].aram_offset);
             return true;
         }
     }
-    
+
     return false;
 }
 
-void bnr_cache_put(u8 game_id[6], BNR* bnr) {
+void bnr_cache_put(u8 game_id[6], u8 disc_num, u8 disc_ver, BNR* bnr) {
     for (int i = 0; i < BNR_CACHE_SIZE; i++) {
-        if (bnr_cache[i].valid && memcmp(bnr_cache[i].game_id, game_id, 6) == 0) {
+        if (bnr_cache_entry_matches(&bnr_cache[i], game_id, disc_num, disc_ver)) {
             return;
         }
     }
@@ -143,6 +155,8 @@ void bnr_cache_put(u8 game_id[6], BNR* bnr) {
     bnr_cache_entry_t* entry = &bnr_cache[bnr_cache_next_index];
     entry->valid = false;
     memcpy(entry->game_id, game_id, 6);
+    entry->disc_num = disc_num;
+    entry->disc_ver = disc_ver;
     entry->aram_offset = (16 * 1024 * 1024) - (sizeof(BNR) * (bnr_cache_next_index + 1));
     bnr_cache_store(bnr, entry->aram_offset);
     entry->valid = true;

--- a/cubeboot/source/emu/tweaks.h
+++ b/cubeboot/source/emu/tweaks.h
@@ -19,8 +19,8 @@ bool emu_can_boot(gm_file_type_t type);
 void emu_draw_boot_error(gm_file_type_t type, u8 ui_alpha);
 bool emu_has_dvd();
 
-bool bnr_cache_get(u8 game_id[6], BNR* bnr);
-void bnr_cache_put(u8 game_id[6], BNR* bnr);
+bool bnr_cache_get(u8 game_id[6], u8 disc_num, u8 disc_ver, BNR* bnr);
+void bnr_cache_put(u8 game_id[6], u8 disc_num, u8 disc_ver, BNR* bnr);
 
 #else
 void ensure_ipl_loaded(uint8_t* bios_buffer);

--- a/patches/source/dolphin_dvd.c
+++ b/patches/source/dolphin_dvd.c
@@ -16,6 +16,8 @@
 #include "flippy_sync.h"
 #include "dvd_threaded.h"
 #include "bnr_offsets.h"
+#include "bnr.h"
+#include "emu/tweaks.h" // bnr_cache_put: warm the banner cache from the validation read
 
 #include "dolphin_os.h"
 
@@ -113,9 +115,13 @@ dolphin_game_into_t get_game_info(char *game_path) {
     u32 fast_bnr_offset = get_banner_offset_fast(&header);
     // OSReport("DEBUG: Fast BNR offset: %08x\n", fast_bnr_offset);
     if (fast_bnr_offset != 0) {
-        dvd_threaded_read(small_buf, 32, fast_bnr_offset, status->fd); //Read in the banner data
+        // Read the FULL banner here (not just the 32-byte magic) so we can warm the banner
+        // cache from this same file handle. gm_load_banner then gets a cache hit and never
+        // reopens the file -- halving file opens per game and removing the disc-2 read delay.
+        __attribute__((aligned(32))) static BNR bnr_buf;
+        dvd_threaded_read(&bnr_buf, sizeof(BNR), fast_bnr_offset, status->fd); //Read in the banner data
 
-        u32 magic = small_buf[0];
+        u32 magic = ((u32*)&bnr_buf)[0];
         if (magic == BANNER_MAGIC_1 || magic == BANNER_MAGIC_2) {
             dolphin_game_into_t info;
             info.valid = true;
@@ -128,6 +134,10 @@ dolphin_game_into_t get_game_info(char *game_path) {
             info.fst_offset = header.FSTOffset;
             info.fst_size = header.FSTSize;
             info.max_fst_size = header.MaxFSTSize;
+
+            // Warm the cache (keyed by full disc identity) so gm_load_banner -- and disc 2+
+            // especially -- can skip reopening the file entirely.
+            bnr_cache_put(info.game_id, info.disc_num, info.disc_ver, &bnr_buf);
 
             dvd_custom_close(status->fd);
             return info;

--- a/patches/source/games.c
+++ b/patches/source/games.c
@@ -563,6 +563,24 @@ void gm_sort_files(int path_count) {
     OSReport("Sort took=%f\n", runtime);
     (void)runtime;
 }
+// Title is the .iso/.gcm filename with the extension stripped (matching Swiss), so
+// multi-disc games are told apart by the "Disc N" in their filename. Names are expected
+// to fit the title box (~28 chars); a longer one is just clipped by the box at draw time
+// (no in-code truncation) -- keep filenames short.
+static void gm_set_title_from_path(gm_file_entry_t *entry) {
+    char *out = entry->desc.fullGameName; // BNR_FULL_TEXT_LEN bytes
+
+    const char *base = strrchr(entry->path, '/');
+    base = base ? base + 1 : entry->path;
+
+    const char *dot = strrchr(base, '.');
+    int len = dot ? (int)(dot - base) : (int)strlen(base);
+    if (len >= BNR_FULL_TEXT_LEN) len = BNR_FULL_TEXT_LEN - 1; // buffer safety only
+
+    memcpy(out, base, len);
+    out[len] = '\0';
+}
+
 // returns amount of space used in aram
 static int gm_load_banner(gm_file_entry_t *entry, u32 aram_offset, bool force_unload, bool use_cache) {
     if (entry->extra.dvd_bnr_offset == 0) return false;
@@ -609,6 +627,10 @@ static int gm_load_banner(gm_file_entry_t *entry, u32 aram_offset, bool force_un
 
     // TODO: check current language using extra.dvd_bnr_type
     memcpy(&entry->desc, &banner_buffer.desc[0], sizeof(BNRDesc));
+
+    // Override the banner's internal name with the .iso filename (the banner name is
+    // identical across discs of the same game). Description/company stay for the info line.
+    gm_set_title_from_path(entry);
 
     return true;
 }
@@ -716,6 +738,7 @@ void gm_check_files(int path_count) {
             memset(backing, 0, sizeof(gm_file_entry_t));
             memcpy(backing->path, entry->path, sizeof(backing->path));
             backing->type = GM_FILE_TYPE_GAME;
+            gm_set_title_from_path(backing); // title even before the banner loads (>128 sliding window)
 
             // copy the extra info
             memcpy(backing->extra.game_id, info.game_id, sizeof(backing->extra.game_id));

--- a/patches/source/games.c
+++ b/patches/source/games.c
@@ -556,6 +556,40 @@ void gm_sort_files(int path_count) {
     OSReport("Sort took=%f\n", runtime);
     (void)runtime;
 }
+// The menu title is the .iso/.gcm filename (matching Swiss), so multi-disc sets can be
+// told apart by the "Disc N" in their filename even when their banners/game IDs match.
+// The title box renders at most TITLE_MAX_CHARS glyphs (draw_blob_text len 0x1f); longer
+// names are middle-ellipsised so the tail survives -- that's where the disc marker sits.
+#define TITLE_MAX_CHARS 31
+
+static void gm_set_title_from_path(gm_file_entry_t *entry) {
+    char *out = entry->desc.fullGameName; // BNR_FULL_TEXT_LEN bytes
+
+    // basename, then drop the extension
+    const char *base = strrchr(entry->path, '/');
+    base = base ? base + 1 : entry->path;
+    const char *dot = strrchr(base, '.');
+    int len = dot ? (int)(dot - base) : (int)strlen(base);
+
+    if (len <= TITLE_MAX_CHARS) {
+        memcpy(out, base, len);
+        out[len] = '\0';
+        return;
+    }
+
+    // middle-ellipsis: head + "..." + tail == TITLE_MAX_CHARS, biased to keep the tail
+    static const char ell[] = "...";
+    const int ell_len = sizeof(ell) - 1;
+    int keep = TITLE_MAX_CHARS - ell_len;
+    int tail = keep - (keep / 2);
+    int head = keep - tail;
+
+    memcpy(out, base, head);
+    memcpy(out + head, ell, ell_len);
+    memcpy(out + head + ell_len, base + (len - tail), tail);
+    out[head + ell_len + tail] = '\0';
+}
+
 // returns amount of space used in aram
 static int gm_load_banner(gm_file_entry_t *entry, u32 aram_offset, bool force_unload, bool use_cache) {
     if (entry->extra.dvd_bnr_offset == 0) return false;
@@ -566,7 +600,7 @@ static int gm_load_banner(gm_file_entry_t *entry, u32 aram_offset, bool force_un
     __attribute_aligned_data_lowmem__ static BNR banner_buffer;
     // use_cache keeps makeo's bnr_cache for the resident (<=128) path; the >128 scroll
     // re-reads pass use_cache=false so they read straight from disc and never touch ARAM.
-    if (use_cache && bnr_cache_get(entry->extra.game_id, &banner_buffer))
+    if (use_cache && bnr_cache_get(entry->extra.game_id, entry->extra.disc_num, entry->extra.disc_ver, &banner_buffer))
         goto cached;
 
     // load the banner
@@ -581,7 +615,7 @@ static int gm_load_banner(gm_file_entry_t *entry, u32 aram_offset, bool force_un
     dvd_threaded_read(&banner_buffer, sizeof(BNR), entry->extra.dvd_bnr_offset, status->fd);
     dvd_custom_close(status->fd);
 
-    if (use_cache) bnr_cache_put(entry->extra.game_id, &banner_buffer);
+    if (use_cache) bnr_cache_put(entry->extra.game_id, entry->extra.disc_num, entry->extra.disc_ver, &banner_buffer);
     cached:
 
     entry->asset.banner.state = GM_LOAD_STATE_LOADING;
@@ -602,6 +636,10 @@ static int gm_load_banner(gm_file_entry_t *entry, u32 aram_offset, bool force_un
 
     // TODO: check current language using extra.dvd_bnr_type
     memcpy(&entry->desc, &banner_buffer.desc[0], sizeof(BNRDesc));
+
+    // Title shows the .iso filename, not the banner's internal name (which is identical
+    // across discs of the same game). The banner's description/company stay for the info line.
+    gm_set_title_from_path(entry);
 
     return true;
 }
@@ -709,6 +747,7 @@ void gm_check_files(int path_count) {
             memset(backing, 0, sizeof(gm_file_entry_t));
             memcpy(backing->path, entry->path, sizeof(backing->path));
             backing->type = GM_FILE_TYPE_GAME;
+            gm_set_title_from_path(backing); // title even before the banner loads (>128 sliding window)
 
             // copy the extra info
             memcpy(backing->extra.game_id, info.game_id, sizeof(backing->extra.game_id));
@@ -761,9 +800,13 @@ void gm_check_files(int path_count) {
             memcpy(backing->path, entry->path, sizeof(backing->path));
             backing->type = entry->type;
 
-            // get the basename
+            // get the basename (bounded copy: fullGameName is BNR_FULL_TEXT_LEN bytes)
             char *base = strrchr(entry->path, '/');
-            strcpy(backing->desc.fullGameName, base + 1);
+            const char *name = base ? base + 1 : entry->path;
+            int nlen = (int)strlen(name);
+            if (nlen >= BNR_FULL_TEXT_LEN) nlen = BNR_FULL_TEXT_LEN - 1;
+            memcpy(backing->desc.fullGameName, name, nlen);
+            backing->desc.fullGameName[nlen] = '\0';
             if (entry->type == GM_FILE_TYPE_PROGRAM) {
                 strcpy(backing->desc.description, "Homebrew Program");
             } else {

--- a/patches/source/games.c
+++ b/patches/source/games.c
@@ -65,13 +65,6 @@ static u32 gm_entry_count = 0;
 // bnr_cache). Reset per folder scan in gm_check_files.
 static bool gm_evict_on_scroll = false;
 
-// True only during the startup fill_cache pre-scan that warms the banner cache across
-// every folder. While set, gm_check_files skips reading extra-disc banners (disc_num > 0):
-// each disc now has its own cache entry (banner fix), and re-reading every disc's banner
-// up front is what slowed the scan. Extra discs load lazily when their folder is opened,
-// so proper per-disc banners are kept without paying for them all at startup.
-static bool gm_prescan_phase = false;
-
 gm_file_entry_t *gm_get_game_entry(int index) {
     if (index >= gm_entry_count) return NULL;
     return gm_entry_backing[index];
@@ -758,11 +751,9 @@ void gm_check_files(int path_count) {
             if (!gm_evict_on_scroll && gm_count_banner_buf() >= ASSET_BUFFER_COUNT) {
                 gm_evict_on_scroll = true;
             }
-            // During the startup pre-scan, only warm the cache with each game's first disc;
-            // extra discs (disc_num > 0) are read lazily when their folder is opened, so the
-            // pre-scan isn't slowed by reading every disc's banner (proper banners kept).
-            bool skip_prescan_extra_disc = gm_prescan_phase && backing->extra.disc_num > 0;
-            if (!gm_evict_on_scroll && !skip_prescan_extra_disc) {
+            // Banner is normally already cached by get_game_info (read during validation),
+            // so this is a cheap cache hit with no extra file open.
+            if (!gm_evict_on_scroll) {
                 bool bnr_loaded = gm_load_banner(backing, aram_offset, force_unload, true);
                 if (!bnr_loaded) {
                     OSReport("Failed to load banner %s\n", entry->path);
@@ -997,7 +988,6 @@ void *gm_thread_worker(void* param) {
     static bool fill_cache = true;
     if (fill_cache) {
         fill_cache = false;
-        gm_prescan_phase = true; // skip extra-disc banner reads while warming the cache
         
         char path_stack[100][128];
         int path_count = 1;
@@ -1036,8 +1026,6 @@ void *gm_thread_worker(void* param) {
                 }
             }
         }
-
-        gm_prescan_phase = false; // pre-scan done; the target folder loads all its discs
     }
 
     gm_list_info list_info = gm_list_files(target);

--- a/patches/source/games.c
+++ b/patches/source/games.c
@@ -65,6 +65,13 @@ static u32 gm_entry_count = 0;
 // bnr_cache). Reset per folder scan in gm_check_files.
 static bool gm_evict_on_scroll = false;
 
+// True only during the startup fill_cache pre-scan that warms the banner cache across
+// every folder. While set, gm_check_files skips reading extra-disc banners (disc_num > 0):
+// each disc now has its own cache entry (banner fix), and re-reading every disc's banner
+// up front is what slowed the scan. Extra discs load lazily when their folder is opened,
+// so proper per-disc banners are kept without paying for them all at startup.
+static bool gm_prescan_phase = false;
+
 gm_file_entry_t *gm_get_game_entry(int index) {
     if (index >= gm_entry_count) return NULL;
     return gm_entry_backing[index];
@@ -556,40 +563,6 @@ void gm_sort_files(int path_count) {
     OSReport("Sort took=%f\n", runtime);
     (void)runtime;
 }
-// The menu title is the .iso/.gcm filename (matching Swiss), so multi-disc sets can be
-// told apart by the "Disc N" in their filename even when their banners/game IDs match.
-// The title box renders at most TITLE_MAX_CHARS glyphs (draw_blob_text len 0x1f); longer
-// names are middle-ellipsised so the tail survives -- that's where the disc marker sits.
-#define TITLE_MAX_CHARS 31
-
-static void gm_set_title_from_path(gm_file_entry_t *entry) {
-    char *out = entry->desc.fullGameName; // BNR_FULL_TEXT_LEN bytes
-
-    // basename, then drop the extension
-    const char *base = strrchr(entry->path, '/');
-    base = base ? base + 1 : entry->path;
-    const char *dot = strrchr(base, '.');
-    int len = dot ? (int)(dot - base) : (int)strlen(base);
-
-    if (len <= TITLE_MAX_CHARS) {
-        memcpy(out, base, len);
-        out[len] = '\0';
-        return;
-    }
-
-    // middle-ellipsis: head + "..." + tail == TITLE_MAX_CHARS, biased to keep the tail
-    static const char ell[] = "...";
-    const int ell_len = sizeof(ell) - 1;
-    int keep = TITLE_MAX_CHARS - ell_len;
-    int tail = keep - (keep / 2);
-    int head = keep - tail;
-
-    memcpy(out, base, head);
-    memcpy(out + head, ell, ell_len);
-    memcpy(out + head + ell_len, base + (len - tail), tail);
-    out[head + ell_len + tail] = '\0';
-}
-
 // returns amount of space used in aram
 static int gm_load_banner(gm_file_entry_t *entry, u32 aram_offset, bool force_unload, bool use_cache) {
     if (entry->extra.dvd_bnr_offset == 0) return false;
@@ -636,10 +609,6 @@ static int gm_load_banner(gm_file_entry_t *entry, u32 aram_offset, bool force_un
 
     // TODO: check current language using extra.dvd_bnr_type
     memcpy(&entry->desc, &banner_buffer.desc[0], sizeof(BNRDesc));
-
-    // Title shows the .iso filename, not the banner's internal name (which is identical
-    // across discs of the same game). The banner's description/company stay for the info line.
-    gm_set_title_from_path(entry);
 
     return true;
 }
@@ -747,7 +716,6 @@ void gm_check_files(int path_count) {
             memset(backing, 0, sizeof(gm_file_entry_t));
             memcpy(backing->path, entry->path, sizeof(backing->path));
             backing->type = GM_FILE_TYPE_GAME;
-            gm_set_title_from_path(backing); // title even before the banner loads (>128 sliding window)
 
             // copy the extra info
             memcpy(backing->extra.game_id, info.game_id, sizeof(backing->extra.game_id));
@@ -767,7 +735,11 @@ void gm_check_files(int path_count) {
             if (!gm_evict_on_scroll && gm_count_banner_buf() >= ASSET_BUFFER_COUNT) {
                 gm_evict_on_scroll = true;
             }
-            if (!gm_evict_on_scroll) {
+            // During the startup pre-scan, only warm the cache with each game's first disc;
+            // extra discs (disc_num > 0) are read lazily when their folder is opened, so the
+            // pre-scan isn't slowed by reading every disc's banner (proper banners kept).
+            bool skip_prescan_extra_disc = gm_prescan_phase && backing->extra.disc_num > 0;
+            if (!gm_evict_on_scroll && !skip_prescan_extra_disc) {
                 bool bnr_loaded = gm_load_banner(backing, aram_offset, force_unload, true);
                 if (!bnr_loaded) {
                     OSReport("Failed to load banner %s\n", entry->path);
@@ -1002,6 +974,7 @@ void *gm_thread_worker(void* param) {
     static bool fill_cache = true;
     if (fill_cache) {
         fill_cache = false;
+        gm_prescan_phase = true; // skip extra-disc banner reads while warming the cache
         
         char path_stack[100][128];
         int path_count = 1;
@@ -1040,6 +1013,8 @@ void *gm_thread_worker(void* param) {
                 }
             }
         }
+
+        gm_prescan_phase = false; // pre-scan done; the target folder loads all its discs
     }
 
     gm_list_info list_info = gm_list_files(target);

--- a/patches/source/games.c
+++ b/patches/source/games.c
@@ -985,54 +985,58 @@ void *gm_thread_worker(void* param) {
         return NULL;
     }
 
-    static bool fill_cache = true;
-    if (fill_cache) {
-        fill_cache = false;
-        
-        char path_stack[100][128];
-        int path_count = 1;
-        strcpy(path_stack[0], "/");
-
-        while (path_count > 0) {
-            char* cur = path_stack[--path_count];
-            gm_list_info list_info = gm_list_files(cur);
-            gm_sort_files(list_info.num_paths);
-            gm_check_files(list_info.num_paths);
-            if (gm_entry_count > 0) {
-                for (int i = 0; i < gm_entry_count; i++) {
-                    gm_file_entry_t *entry = gm_entry_backing[i];
-                    if (entry->type == GM_FILE_TYPE_GAME) {
-                        gm_icon_free(&entry->asset.icon);
-                        gm_banner_free(&entry->asset.banner);
-                    } else {
-                        gm_icon_free(&entry->asset.icon);
-                    }
-                    gm_free(entry);
-                }
-                gm_entry_count = 0;
-            }
-
-            for (int i = 0; i < list_info.num_paths; i++) {
-                gm_path_entry_t* entry = __gm_sorted_path_list[i];
-
-                if (entry->type == GM_FILE_TYPE_DIRECTORY) {
-                    char subdir_path[128];
-                    strcpy(subdir_path, entry->path);
-                    strcat(subdir_path, "/");
-
-                    if (path_count < 100) {
-                        strcpy(path_stack[path_count++], subdir_path);
-                    }
-                }
-            }
-        }
-    }
-
+    // --- Lever A, step 1: scan ONLY the landing folder and draw its list first ---
+    // The menu draws from game_backing_count (populated by gm_check_files), not from
+    // game_enum_running, so the user sees their default_folder immediately instead of
+    // waiting for every banner on the whole card to be read.
     gm_list_info list_info = gm_list_files(target);
     gm_setup_grid(list_info.num_paths, true);
     gm_sort_files(list_info.num_paths);
     gm_check_files(list_info.num_paths);
     gm_setup_grid(gm_entry_count, false);
+
+    // --- Lever A, step 2: warm the rest of the card's banner cache in the background ---
+    // First boot only, running behind the now-live menu on this same worker thread. We touch
+    // ONLY the banner cache (via get_game_info, which caches each banner it reads) -- never the
+    // live display arrays (gm_entry_backing/gm_entry_count) or the banner pool -- so the grid
+    // on screen is undisturbed. Navigation and game boot both call gm_deinit_thread(), which
+    // locks game_enum_mutex; we honour it cooperatively (same as gm_check_files) and bail, so
+    // the user never waits on this pass. The landing folder is skipped (already read above).
+    static bool fill_cache = true;
+    if (fill_cache) {
+        fill_cache = false;
+
+        char path_stack[100][128];
+        int path_count = 1;
+        strcpy(path_stack[0], "/");
+
+        bool stop = false;
+        while (path_count > 0 && !stop) {
+            char cur[128];
+            strcpy(cur, path_stack[--path_count]);
+            bool is_target = (strcmp(cur, target) == 0);
+
+            gm_list_info warm_info = gm_list_files(cur);
+            for (int i = 0; i < warm_info.num_paths; i++) {
+                // Let navigation / boot preempt the warm promptly.
+                if (!OSTryLockMutex(game_enum_mutex)) { stop = true; break; }
+                OSUnlockMutex(game_enum_mutex);
+
+                gm_path_entry_t* entry = __gm_sorted_path_list[i];
+                if (entry->type == GM_FILE_TYPE_DIRECTORY) {
+                    if (path_count < 100) {
+                        char subdir_path[128];
+                        strcpy(subdir_path, entry->path);
+                        strcat(subdir_path, "/");
+                        strcpy(path_stack[path_count++], subdir_path);
+                    }
+                } else if (entry->type == GM_FILE_TYPE_GAME && !is_target) {
+                    // Warm bnr_cache for this disc; the returned info is intentionally discarded.
+                    get_game_info(entry->path);
+                }
+            }
+        }
+    }
 
     game_enum_running = false;
     // DCBlockStore((void*)OSRoundDown32B((u32)&game_enum_running));

--- a/patches/source/menu.c
+++ b/patches/source/menu.c
@@ -651,7 +651,16 @@ __attribute_used__ void custom_gameselect_menu(u8 broken_alpha_0, u8 alpha_1, u8
 
         // info
         draw_blob_text(make_type('t','i','t','l'), menu_blob, &white, entry->desc.fullGameName, 0x1f);
-        draw_blob_text(make_type('i','n','f','o'), menu_blob, &white, entry->desc.description, 0x1f);
+        if (entry->second != NULL) {
+            // Multi-disc game: show the disc number on the second line instead of the
+            // description, so discs of the same game (which can share a banner and name)
+            // are distinguishable while browsing.
+            char disc_line[16];
+            snprintf(disc_line, sizeof(disc_line), "Disc %d", entry->extra.disc_num + 1);
+            draw_blob_text(make_type('i','n','f','o'), menu_blob, &white, disc_line, 0x1f);
+        } else {
+            draw_blob_text(make_type('i','n','f','o'), menu_blob, &white, entry->desc.description, 0x1f);
+        }
 
         switch_lang_eng();
         if (entry->type == GM_FILE_TYPE_PROGRAM || entry->type == GM_FILE_TYPE_DIRECTORY) {

--- a/patches/source/menu.c
+++ b/patches/source/menu.c
@@ -651,16 +651,7 @@ __attribute_used__ void custom_gameselect_menu(u8 broken_alpha_0, u8 alpha_1, u8
 
         // info
         draw_blob_text(make_type('t','i','t','l'), menu_blob, &white, entry->desc.fullGameName, 0x1f);
-        if (entry->second != NULL) {
-            // Multi-disc game: show the disc number on the second line instead of the
-            // description, so discs of the same game (which can share a banner and name)
-            // are distinguishable while browsing.
-            char disc_line[16];
-            snprintf(disc_line, sizeof(disc_line), "Disc %d", entry->extra.disc_num + 1);
-            draw_blob_text(make_type('i','n','f','o'), menu_blob, &white, disc_line, 0x1f);
-        } else {
-            draw_blob_text(make_type('i','n','f','o'), menu_blob, &white, entry->desc.description, 0x1f);
-        }
+        draw_blob_text(make_type('i','n','f','o'), menu_blob, &white, entry->desc.description, 0x1f);
 
         switch_lang_eng();
         if (entry->type == GM_FILE_TYPE_PROGRAM || entry->type == GM_FILE_TYPE_DIRECTORY) {
@@ -729,15 +720,7 @@ __attribute_used__ void original_gameselect_menu(u8 broken_alpha_0, u8 alpha_1, 
     draw_blob_text(make_type('t','i','t','l'), game_blob_b, &white, entry->desc.fullGameName, 0x40);
     if (entry->type == GM_FILE_TYPE_GAME) {
         draw_blob_text(make_type('m','a','k','r'), game_blob_b, &white, entry->desc.fullCompany, 0x40);
-        if (entry->second != NULL) {
-            // Multi-disc: show the disc number instead of the description here too, so
-            // discs of the same game stay distinguishable in the expanded detail view.
-            char disc_line[16];
-            snprintf(disc_line, sizeof(disc_line), "Disc %d", entry->extra.disc_num + 1);
-            draw_blob_text_long(make_type('i','n','f','o'), game_blob_b, &white, disc_line, 0x80);
-        } else {
-            draw_blob_text_long(make_type('i','n','f','o'), game_blob_b, &white, entry->desc.description, 0x80);
-        }
+        draw_blob_text_long(make_type('i','n','f','o'), game_blob_b, &white, entry->desc.description, 0x80);
     } else {
         draw_blob_text(make_type('m','a','k','r'), game_blob_b, &white, entry->desc.description, 0x40);
     }

--- a/patches/source/menu.c
+++ b/patches/source/menu.c
@@ -729,7 +729,15 @@ __attribute_used__ void original_gameselect_menu(u8 broken_alpha_0, u8 alpha_1, 
     draw_blob_text(make_type('t','i','t','l'), game_blob_b, &white, entry->desc.fullGameName, 0x40);
     if (entry->type == GM_FILE_TYPE_GAME) {
         draw_blob_text(make_type('m','a','k','r'), game_blob_b, &white, entry->desc.fullCompany, 0x40);
-        draw_blob_text_long(make_type('i','n','f','o'), game_blob_b, &white, entry->desc.description, 0x80);
+        if (entry->second != NULL) {
+            // Multi-disc: show the disc number instead of the description here too, so
+            // discs of the same game stay distinguishable in the expanded detail view.
+            char disc_line[16];
+            snprintf(disc_line, sizeof(disc_line), "Disc %d", entry->extra.disc_num + 1);
+            draw_blob_text_long(make_type('i','n','f','o'), game_blob_b, &white, disc_line, 0x80);
+        } else {
+            draw_blob_text_long(make_type('i','n','f','o'), game_blob_b, &white, entry->desc.description, 0x80);
+        }
     } else {
         draw_blob_text(make_type('m','a','k','r'), game_blob_b, &white, entry->desc.description, 0x40);
     }


### PR DESCRIPTION
Builds on the `default_folder` feature (#3). Two related improvements to the games menu, plus a cold-boot speedup that leans on `default_folder`.

## 1. Multi-disc games are told apart correctly
Previously, discs of the same game (same game ID, e.g. *Baten Kaitos* Disc 1/Disc 2) all showed **disc 1's** banner and name, because the banner cache was keyed by game ID alone. Now:
- Banner cache is keyed by full disc identity (id + disc number + version) — each disc shows **its own** banner.
- Title is the **`.iso` filename** (extension stripped, matching Swiss), so the "Disc N" in the filename distinguishes discs. Keep filenames ≤ ~28 chars to fit the title box (no in-code truncation; the box clips).
- Disc number is shown on the info line **and** in the expanded detail view.

Commits: `26e9d88`, `23282c1`, `2abb55d`, `5401a0c`.

## 2. Faster scan, then instant cold boot

**`c23c2ab` — fold the banner read into validation.** `get_game_info` already opened each `.iso` to check the banner magic; now it reads the full banner there and warms the cache, so `gm_load_banner` gets a cache hit and never reopens the file. Roughly halves file opens per game (the dominant cost on SD/FAT).

**`94719f8` — Lever A: draw your folder first, warm the rest in the background.** Cold boot used to read **every banner on the whole card** (the `fill_cache` walk in `gm_thread_worker`) *before* drawing the list — so with a `default_folder` set you waited for the entire card to see one folder. Reordered: scan the landing folder and build the grid **first** (the menu draws from `game_backing_count`, so it's interactive immediately), then warm the rest of the card's banner cache **behind the live menu**. The background pass calls `get_game_info()` only — it never touches the live display arrays or the banner pool, and it honours `game_enum_mutex`, so the `gm_deinit_thread()` that navigation and game boot already call preempts it. The user never waits on it.

Effect: cold-boot **time-to-first-list drops from "every banner on the card" to "just your folder."** Other folders still end up warm in the background.

## Verification
- Clean Docker build (devkitPPC, cube-only): `dist/IPL.dol` ~663 KB + `apploader.img` regenerated.
- Maintainer hardware test: multi-disc banners/names correct, no banner corruption, and **cold boot now loads instantly.**

## Safety note
`94719f8` lives in the cold-boot-sensitive enum / `fill_cache` path (same area as the earlier banner-corruption fix), so it's an **isolated, single-`git revert` commit** — back it out alone if a future cold-boot regression ever appears, keeping proper banners + filename titles with the older startup speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)