### PR TITLE
fix(boot): swiss-gc.dol from a folder hard-reset to IPL (regression since v1.4)

### DIFF
--- a/patches/source/dolphin_dvd.c
+++ b/patches/source/dolphin_dvd.c
@@ -115,13 +115,13 @@ dolphin_game_into_t get_game_info(char *game_path) {
     u32 fast_bnr_offset = get_banner_offset_fast(&header);
     // OSReport("DEBUG: Fast BNR offset: %08x\n", fast_bnr_offset);
     if (fast_bnr_offset != 0) {
-        // Read the FULL banner here (not just the 32-byte magic) so we can warm the banner
-        // cache from this same file handle. gm_load_banner then gets a cache hit and never
-        // reopens the file -- halving file opens per game and removing the disc-2 read delay.
-        __attribute__((aligned(32))) static BNR bnr_buf;
-        dvd_threaded_read(&bnr_buf, sizeof(BNR), fast_bnr_offset, status->fd); //Read in the banner data
+        // Validate with just the 32-byte magic here; gm_load_banner reads the full banner
+        // when it actually needs it. (The fast-path that read the whole 8KB banner into a
+        // static buffer grew the loader by ~8KB and broke launching swiss-gc.dol from a
+        // folder -- the boot would hard-reset to the console IPL.)
+        dvd_threaded_read(small_buf, 32, fast_bnr_offset, status->fd); //Read in the banner data
 
-        u32 magic = ((u32*)&bnr_buf)[0];
+        u32 magic = small_buf[0];
         if (magic == BANNER_MAGIC_1 || magic == BANNER_MAGIC_2) {
             dolphin_game_into_t info;
             info.valid = true;
@@ -134,10 +134,6 @@ dolphin_game_into_t get_game_info(char *game_path) {
             info.fst_offset = header.FSTOffset;
             info.fst_size = header.FSTSize;
             info.max_fst_size = header.MaxFSTSize;
-
-            // Warm the cache (keyed by full disc identity) so gm_load_banner -- and disc 2+
-            // especially -- can skip reopening the file entirely.
-            bnr_cache_put(info.game_id, info.disc_num, info.disc_ver, &bnr_buf);
 
             dvd_custom_close(status->fd);
             return info;

--- a/patches/source/games.c
+++ b/patches/source/games.c
@@ -985,58 +985,22 @@ void *gm_thread_worker(void* param) {
         return NULL;
     }
 
-    // --- Lever A, step 1: scan ONLY the landing folder and draw its list first ---
-    // The menu draws from game_backing_count (populated by gm_check_files), not from
-    // game_enum_running, so the user sees their default_folder immediately instead of
-    // waiting for every banner on the whole card to be read.
+    // Scan ONLY the folder we land in, then draw its list. The menu draws from
+    // game_backing_count (populated by gm_check_files), so the default_folder appears
+    // immediately -- that is the instant cold boot. Other folders are read on demand when
+    // opened (banners load on first visit, then stay cached for the session).
+    //
+    // There is deliberately NO whole-card background warm. Warming every folder up front
+    // needs its own dedicated banner buffer (so it can't race the live menu's banner_buffer),
+    // and that extra 8KB buffer is exactly what grew the loader image and broke launching
+    // swiss-gc.dol from a folder (the boot hard-reset to the console IPL). The instant boot
+    // comes from scanning just this folder -- not from the warm -- so dropping the warm keeps
+    // the speed and fixes the regression.
     gm_list_info list_info = gm_list_files(target);
     gm_setup_grid(list_info.num_paths, true);
     gm_sort_files(list_info.num_paths);
     gm_check_files(list_info.num_paths);
     gm_setup_grid(gm_entry_count, false);
-
-    // --- Lever A, step 2: warm the rest of the card's banner cache in the background ---
-    // First boot only, running behind the now-live menu on this same worker thread. We touch
-    // ONLY the banner cache (via get_game_info, which caches each banner it reads) -- never the
-    // live display arrays (gm_entry_backing/gm_entry_count) or the banner pool -- so the grid
-    // on screen is undisturbed. Navigation and game boot both call gm_deinit_thread(), which
-    // locks game_enum_mutex; we honour it cooperatively (same as gm_check_files) and bail, so
-    // the user never waits on this pass. The landing folder is skipped (already read above).
-    static bool fill_cache = true;
-    if (fill_cache) {
-        fill_cache = false;
-
-        char path_stack[100][128];
-        int path_count = 1;
-        strcpy(path_stack[0], "/");
-
-        bool stop = false;
-        while (path_count > 0 && !stop) {
-            char cur[128];
-            strcpy(cur, path_stack[--path_count]);
-            bool is_target = (strcmp(cur, target) == 0);
-
-            gm_list_info warm_info = gm_list_files(cur);
-            for (int i = 0; i < warm_info.num_paths; i++) {
-                // Let navigation / boot preempt the warm promptly.
-                if (!OSTryLockMutex(game_enum_mutex)) { stop = true; break; }
-                OSUnlockMutex(game_enum_mutex);
-
-                gm_path_entry_t* entry = __gm_sorted_path_list[i];
-                if (entry->type == GM_FILE_TYPE_DIRECTORY) {
-                    if (path_count < 100) {
-                        char subdir_path[128];
-                        strcpy(subdir_path, entry->path);
-                        strcat(subdir_path, "/");
-                        strcpy(path_stack[path_count++], subdir_path);
-                    }
-                } else if (entry->type == GM_FILE_TYPE_GAME && !is_target) {
-                    // Warm bnr_cache for this disc; the returned info is intentionally discarded.
-                    get_game_info(entry->path);
-                }
-            }
-        }
-    }
 
     game_enum_running = false;
     // DCBlockStore((void*)OSRoundDown32B((u32)&game_enum_running));


### PR DESCRIPTION
## The bug
Since **v1.4**, launching a `swiss*.dol` from a **subfolder** via the cubiboot menu hard-reset the console to the original IPL. Regular games and other `.dol`s were unaffected. Reported by the maintainer.

## Root cause (bisected v1.2..v1.4 on hardware)
`5401a0c` works, **`c23c2ab` fails**. The DOL boot path itself (`chainload_swiss_game`'s `is_swiss` dirty hack → `load_dol_file` + `run`) is **byte-identical to v1.2** — so it was corrupted *state*, not the boot code.

`c23c2ab`'s fast-path gave `get_game_info` its own dedicated `static BNR bnr_buf` (**8096 bytes**) so Lever A's background warm could read/cache banners without racing the live menu's `banner_buffer`. That ~8 KB grew the loader image, and the larger image broke the Swiss DOL chainload (jumped to a bad entry → hard reset). The failure tracked the +8 KB exactly:

| Build | `IPL.dol` | Swiss-from-folder |
|---|---|---|
| 5401a0c | 670,976 | ✅ |
| c23c2ab | 679,072 (**+8 KB**) | ❌ |
| diagnostic (cache off, buffer kept) | 678,944 | ❌ |
| **this fix** | 669,952 | ✅ |

The diagnostic that disabled caching but kept the buffer still failed → it was the **buffer/size**, not the ARAM cache.

## The fix
- **`dolphin_dvd.c`** — revert `get_game_info` to the 32-byte magic-check read (drop the 8 KB `bnr_buf` and its `bnr_cache_put`). `gm_load_banner` reads the full banner on demand, as before.
- **`games.c`** — drop the whole-card background warm from `gm_thread_worker`. It only existed to use that buffer's caching, so without the fast-path it has nothing to cache. **Instant cold boot is unaffected** — it comes from scanning *only the landing folder* (kept), never from the warm. Other folders load on first visit, then cache for the session (the natural makeo behaviour).

## Net result
Scan only the landing folder (instant boot) + on-demand per-folder loading + the **disc-naming feature**, all intact. **Confirmed fixed on hardware by the maintainer.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)