### PR TITLE
ci: fix the bullseye EOL mirror purge, and take the image build off every run

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -3,10 +3,33 @@
 # Used by .github/workflows/ci.yml (docker build - < .ci/Dockerfile).
 FROM devkitpro/devkitppc:20231110
 
-RUN apt-get update && apt-get install -y \
-        genisoimage git golang nodejs build-essential gcc-arm-none-eabi \
-        python3-pip python3-distutils python3-setuptools curl xz-utils zip \
-    && rm -rf /var/lib/apt/lists/*
+# Debian 11 (bullseye) reached end of life on 2026-08-31, so the live mirrors are
+# being purged while their indexes still advertise the packages: apt resolves
+# python3-setuptools 52.0.0-4+deb11u2 and then gets a 404 on the .deb, which fails
+# the image build (and is not transient, so the workflow's 5 retries all fail).
+# The live mirror is still tried first -- when it is intact this behaves exactly as
+# before -- and only on failure does the suite get repointed at archive.debian.org,
+# which is frozen and complete. Check-Valid-Until is off because the archived
+# Release files are past their expiry date by design.
+RUN set -eux; \
+    PKGS="genisoimage git golang nodejs build-essential gcc-arm-none-eabi \
+          python3-pip python3-distutils python3-setuptools curl xz-utils zip"; \
+    echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-cubiboot-retries; \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-cubiboot-archive; \
+    if ! (apt-get update && apt-get install -y $PKGS); then \
+        echo "live Debian mirror incomplete; falling back to archive.debian.org" >&2; \
+        printf '%s\n' \
+            'deb http://archive.debian.org/debian bullseye main' \
+            'deb http://archive.debian.org/debian-security bullseye-security main' \
+            > /etc/apt/sources.list; \
+        for f in /etc/apt/sources.list.d/*.list; do \
+            [ -f "$f" ] || continue; \
+            sed -i -E 's,https?://(deb|security)\.debian\.org/debian-security,http://archive.debian.org/debian-security,g; s,https?://deb\.debian\.org/debian,http://archive.debian.org/debian,g' "$f"; \
+        done; \
+        apt-get update; \
+        apt-get install -y $PKGS; \
+    fi; \
+    rm -rf /var/lib/apt/lists/*
 
 # pip via apt (the image ships Python 3.9; current get-pip.py needs 3.10+)
 RUN pip3 install pyelftools==0.28

--- a/.ci/toolchain_image.sh
+++ b/.ci/toolchain_image.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Puts the cubiboot-dev toolchain image in place for every `docker run ...
+# cubiboot-dev` step in .github/workflows/ci.yml. Two ways to get there:
+#
+#   1. pull the prebuilt image published by .github/workflows/toolchain.yml,
+#      pinned by digest in .ci/toolchain.digest -- no apt, no libogc2 compile,
+#      and nothing in the run depends on Debian's mirrors still serving
+#      bullseye;
+#   2. build it here from .ci/Dockerfile, byte for byte the step CI has always
+#      run.
+#
+# (2) is not a nicety. It is what keeps this repo buildable when the digest file
+# is absent (the state this script ships in: behaviour identical to before),
+# when GHCR is unreachable, and -- the case that matters -- when .ci/Dockerfile
+# has been edited since the image was published. A pinned image is the WRONG
+# toolchain then, so it is deliberately ignored rather than silently used, and
+# the run says so. Deleting .ci/toolchain.digest is a complete rollback to the
+# old behaviour, with no other change anywhere.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+DIGEST_FILE=.ci/toolchain.digest
+dockerfile_hash="$(sha256sum .ci/Dockerfile | cut -d' ' -f1)"
+
+build_locally() {
+    echo ">> building the toolchain image from .ci/Dockerfile"
+    # Retry: the Docker Hub base-image pull can hit transient i/o timeouts on
+    # runners.
+    for i in 1 2 3 4 5; do
+        docker build -t cubiboot-dev - < .ci/Dockerfile && return 0
+        echo "docker build attempt $i failed; retrying in 20s..." >&2
+        sleep 20
+    done
+    echo "docker build failed after 5 attempts" >&2
+    return 1
+}
+
+use_prebuilt() {
+    local image="$1"
+    for i in 1 2 3; do
+        if docker pull "$image"; then
+            docker tag "$image" cubiboot-dev
+            echo ">> using prebuilt toolchain image $image"
+            return 0
+        fi
+        echo "docker pull attempt $i failed; retrying in 10s..." >&2
+        sleep 10
+    done
+    return 1
+}
+
+if [ -f "$DIGEST_FILE" ]; then
+    image="$(sed -n 's/^image=//p' "$DIGEST_FILE" | tail -n1)"
+    recorded="$(sed -n 's/^dockerfile_sha256=//p' "$DIGEST_FILE" | tail -n1)"
+
+    if [ -z "$image" ] || [ -z "$recorded" ]; then
+        echo "::warning::$DIGEST_FILE is missing an image= or dockerfile_sha256= line; building the toolchain image from .ci/Dockerfile instead"
+    elif [ "$recorded" != "$dockerfile_hash" ]; then
+        echo "::warning::.ci/Dockerfile has changed since $image was published (recorded $recorded, current $dockerfile_hash), so the pinned image is the wrong toolchain and is being ignored. This build is correct but slower. Run the 'Toolchain image' workflow and commit the digest it prints to go back to the prebuilt image."
+    elif use_prebuilt "$image"; then
+        exit 0
+    else
+        echo "::warning::could not pull $image; building the toolchain image from .ci/Dockerfile instead"
+    fi
+fi
+
+build_locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write   # needed to create Releases on tag pushes
+  packages: read    # to pull the prebuilt toolchain image (see .ci/toolchain_image.sh)
 
 jobs:
   build:
@@ -16,17 +17,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Build the reproducible toolchain image (devkitPPC + pinned libogc2/libfat).
-      # Retry: the Docker Hub base-image pull can hit transient i/o timeouts on runners.
-      - name: Build cubiboot-dev image
+      # The prebuilt toolchain image, when there is one, is published under the
+      # repo owner's namespace, so the pull needs a login. Not fatal: without it
+      # the next step just builds the image from .ci/Dockerfile, as always.
+      - name: Log in to GHCR
         run: |
-          for i in 1 2 3 4 5; do
-            docker build -t cubiboot-dev - < .ci/Dockerfile && exit 0
-            echo "docker build attempt $i failed; retrying in 20s..." >&2
-            sleep 20
-          done
-          echo "docker build failed after 5 attempts" >&2
-          exit 1
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin \
+            || echo "::warning::ghcr.io login failed; the toolchain image will be built locally"
+
+      # Provide the reproducible toolchain image (devkitPPC + pinned libogc2/libfat):
+      # pull the pinned prebuilt one if .ci/toolchain.digest says so and it still
+      # matches .ci/Dockerfile, otherwise build it here exactly as CI always did.
+      # Every step below runs `docker run ... cubiboot-dev` either way.
+      - name: Provide the cubiboot-dev image
+        run: bash .ci/toolchain_image.sh
 
       # The version shown under the banner, on the menu cube and on the .iso BIOS intro.
       # Stamped from the tag being built so a release cannot ship the previous version's

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -1,0 +1,125 @@
+name: Toolchain image
+
+# Publishes the cubiboot-dev build image to GHCR so ci.yml can pull one frozen
+# toolchain instead of assembling it on every push: 367 MB of apt plus a
+# libogc2/libfat compile, against mirrors that are being purged now that Debian
+# 11 is end of life. That assembly is what took CI down; a pinned image takes
+# it off the critical path of every build and every release.
+#
+# Nothing switches over by itself. ci.yml keeps building the image locally until
+# .ci/toolchain.digest exists, so publishing an image changes no build on its
+# own -- adopting it is a separate, one-line commit, and deleting that file is a
+# complete rollback.
+#
+# main only: publishing writes a package under the repo owner's namespace, and
+# main is where releases are cut, so it is not something a topic branch does as
+# a side effect.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .ci/Dockerfile
+      - .github/workflows/toolchain.yml
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build the image from .ci/Dockerfile
+        run: |
+          for i in 1 2 3 4 5; do
+            docker build -t cubiboot-dev - < .ci/Dockerfile && exit 0
+            echo "docker build attempt $i failed; retrying in 20s..." >&2
+            sleep 20
+          done
+          echo "docker build failed after 5 attempts" >&2
+          exit 1
+
+      # Build the loader and the menu in the image as built here, keep the
+      # binaries, then throw the local tags away, pull the image back by the
+      # digest ci.yml would pin, and build again. The two sets of binaries must
+      # match byte for byte.
+      #
+      # Being honest about what this proves: the pinned image is this image, so
+      # equal output is expected -- what is under test is the mechanism ci.yml
+      # will depend on (digest resolves, pull works, retag works, the project
+      # actually compiles in the pulled image), before any of it is adopted.
+      # It is also a real check that this image builds the project at all,
+      # which is the thing you do not want to discover on a tag push.
+      - name: Build in the image, then in the same image pulled back by digest
+        id: verify
+        run: |
+          set -e
+          IMAGE="ghcr.io/$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')/cubiboot-dev"
+          TAG="$(date -u +%Y%m%d)-$(git rev-parse --short HEAD)"
+          STAMP="$(git rev-parse --short HEAD)"
+
+          docker tag cubiboot-dev "$IMAGE:$TAG"
+          docker push "$IMAGE:$TAG"
+          DIGEST="$(docker inspect --format '{{index .RepoDigests 0}}' "$IMAGE:$TAG")"
+          echo ">> published $DIGEST"
+
+          python3 .ci/brand_opening.py patches/data/default_opening.bin "$STAMP"
+          docker run --rm -v "$PWD":/work -e CUBIBOOT_VERSION="$STAMP" cubiboot-dev \
+            bash -lc 'cd entry && make clean && make'
+          mkdir -p /tmp/from-local
+          cp cubeboot/cubeboot.dol patches/patches.elf entry/entry.dol /tmp/from-local/
+
+          # Drop every local reference, including the digest one `docker push`
+          # leaves behind, so the pull below really comes from GHCR instead of
+          # finding the layers still on the runner.
+          docker rmi -f cubiboot-dev "$IMAGE:$TAG" "$DIGEST" || true
+          docker image prune -af
+          docker pull "$DIGEST"
+          docker tag "$DIGEST" cubiboot-dev
+          docker run --rm -v "$PWD":/work -e CUBIBOOT_VERSION="$STAMP" cubiboot-dev \
+            bash -lc 'cd entry && make clean && make'
+
+          for f in cubeboot/cubeboot.dol patches/patches.elf entry/entry.dol; do
+            cmp "/tmp/from-local/$(basename "$f")" "$f"
+            echo "identical: $f ($(stat -c%s "$f") bytes)"
+          done
+
+          echo "image=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "dockerfile_sha256=$(sha256sum .ci/Dockerfile | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      # The two lines to commit as .ci/toolchain.digest to make ci.yml pull this
+      # image. Printed rather than committed: the switch stays a human decision,
+      # and the commit that makes it is the one to revert to undo it.
+      - name: Print the digest to adopt
+        run: |
+          {
+            echo '## Toolchain image published'
+            echo
+            echo 'Binaries verified identical across the push/pull round trip. To make'
+            echo '`ci.yml` pull this image, commit these two lines as `.ci/toolchain.digest`:'
+            echo
+            echo '```'
+            echo 'image=${{ steps.verify.outputs.image }}'
+            echo 'dockerfile_sha256=${{ steps.verify.outputs.dockerfile_sha256 }}'
+            echo '```'
+            echo
+            echo 'Until that file exists, every build keeps assembling the image from'
+            echo '`.ci/Dockerfile` exactly as before. Deleting it later is a full rollback.'
+          } >> "$GITHUB_STEP_SUMMARY"
+          printf 'image=%s\ndockerfile_sha256=%s\n' \
+            '${{ steps.verify.outputs.image }}' \
+            '${{ steps.verify.outputs.dockerfile_sha256 }}' \
+            | tee toolchain.digest
+
+      - name: Upload the digest file
+        uses: actions/upload-artifact@v4
+        with:
+          name: toolchain-digest
+          path: toolchain.digest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,14 @@ picking up your edits is the classic failure here.
 
 CI runs the same steps from `.ci/` on every branch — see `.github/workflows/ci.yml`.
 
+The toolchain container comes from `.ci/toolchain_image.sh`: it pulls the prebuilt image
+pinned in `.ci/toolchain.digest` (published by `.github/workflows/toolchain.yml`), and
+builds from `.ci/Dockerfile` instead whenever that file is absent, the pull fails, or
+`.ci/Dockerfile` has changed since the image was published — so **editing the Dockerfile
+never silently builds against the old toolchain**, it just makes the run slower and prints
+a warning. After changing `.ci/Dockerfile`, re-run the *Toolchain image* workflow and commit
+the two lines it prints; deleting `.ci/toolchain.digest` reverts to building every time.
+
 ## Hard rules
 
 - **Never mask the build's exit code** with `| tail`, `| head` or `; echo`. Redirect to a


### PR DESCRIPTION
Every run since 2026-08-29 fails, on any commit. `main` is red now on a README-only commit, which is not the cause.

## What broke

Debian 11 (bullseye) — the base of `devkitpro/devkitppc:20231110` — reached end of life on 2026-08-31. The live mirrors are being purged while their indexes still advertise the packages, so `apt-get install` inside `.ci/Dockerfile` resolves `python3-setuptools 52.0.0-4+deb11u2` and then 404s on the `.deb`:

```
Err:109 .../python3-setuptools 52.0.0-4+deb11u2
  404  Not Found
E: Failed to fetch .../python3-setuptools_52.0.0-4%2bdeb11u2_all.deb  404  Not Found
ERROR: process "/bin/sh -c apt-get update && apt-get install -y ..." exit code: 100
docker build failed after 5 attempts
```

A fetch error, not a network blip, so all five `docker build` retries hit the same wall. The package cannot simply be dropped: `python3-pip` depends on it, and pip is what installs `pyelftools`, which `patches/Makefile:149` needs via `scripts/patch-size.py`.

## `f9aef42` — the fix that unblocks CI

The apt stage tries the live mirror exactly as before and only on failure repoints `bullseye`/`bullseye-security` at `archive.debian.org`, which is frozen and complete, then retries the same package list. `Check-Valid-Until` is off because archived `Release` files are past their expiry by design; `Acquire::Retries` covers genuinely transient fetch errors. Base image, package list and the libogc2/libfat pins are unchanged.

## `3931f8c` — the image build off the critical path

Assembling the toolchain on every push (367 MB of apt plus a libogc2/libfat compile, against mirrors that are now being purged) is what took CI down in the first place, and it sits in front of every build and every release. This prepares publishing the image once and pinning it by digest, staged so it cannot break a build or a release:

- `ci.yml` no longer inlines `docker build`; it calls `.ci/toolchain_image.sh`, which pulls the image pinned in `.ci/toolchain.digest` and otherwise builds from `.ci/Dockerfile` exactly as the old step did. **That file does not exist yet**, so merging this changes no build behaviour. Adopting the pin is a separate two-line commit; deleting the file is a full rollback.
- The local build is also the fallback for a failed pull, a failed GHCR login, a malformed digest file, and — deliberately — a `.ci/Dockerfile` that changed since the image was published: a pinned image is the wrong toolchain then, so it is ignored with a warning rather than silently used. A stale pin cannot quietly outlive an edit to the Dockerfile.
- `toolchain.yml` publishes to GHCR from `main` only, then pushes, drops every local layer, pulls back by digest and rebuilds, requiring `cubeboot.dol`, `patches.elf` and `entry.dol` to be byte-identical before it prints the digest to adopt. What that proves is the mechanism `ci.yml` will depend on, plus that the image builds the project at all — equal bytes are expected, since the pinned image is that image.

Downstream steps are untouched: they still run `docker run ... cubiboot-dev`, whichever way the image arrived.

## Verification

- Run [185](https://github.com/DarthMotzkus/cubiboot-new-ui/actions/runs/33908636264) (`f9aef42`) green: image built, all artefacts produced.
- Run [186](https://github.com/DarthMotzkus/cubiboot-new-ui/actions/runs/33910253292) (`3931f8c`) green through the rewritten steps — *Log in to GHCR*, then *Provide the cubiboot-dev image* taking the local-build path, which is the expected path with no digest file — and `ipl.dol`, `apploader.img`, `cubiboot.iso` and both `.uf2` out as before.
- Locally: both workflow files parse as YAML, `.ci/toolchain_image.sh` passes `bash -n`, and all five of its decision paths were exercised against a stubbed `docker`. The Dockerfile's joined `RUN` body passes `sh -n`, and both apt paths were run against a stubbed `apt-get` and a fake `/etc/apt`.
- Not verified here, and worth saying plainly: the image itself could not be built in this environment (no docker daemon, Debian hosts off the network allowlist), so CI is the check. Nothing in this PR touches `cubeboot/`, `patches/` or `entry/`, so no hardware validation is implicated.

## After merging

`toolchain.yml` runs (it publishes a package under the repo owner's namespace, which is why it is `main`-only), verifies the round trip and prints two lines. Commit them as `.ci/toolchain.digest` to make CI pull the image; leave them uncommitted and everything keeps working as it does today.

`.localbuild/Dockerfile` is gitignored, so the apt fix could not be applied there — worth copying the new block across if it mirrors the same `apt-get` stage, or the WSL build will break the same way once the purge completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dczt8oPHTTjqJdMwnEhEcc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dczt8oPHTTjqJdMwnEhEcc)_