### PR TITLE
ci: pin the published toolchain image; fix the two things its first run exposed

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -4,13 +4,23 @@
 FROM devkitpro/devkitppc:20231110
 
 # Debian 11 (bullseye) reached end of life on 2026-08-31, so the live mirrors are
-# being purged while their indexes still advertise the packages: apt resolves
-# python3-setuptools 52.0.0-4+deb11u2 and then gets a 404 on the .deb, which fails
-# the image build (and is not transient, so the workflow's 5 retries all fail).
-# The live mirror is still tried first -- when it is intact this behaves exactly as
-# before -- and only on failure does the suite get repointed at archive.debian.org,
+# being purged while their indexes still advertise the packages: apt resolves a
+# version and then gets a 404 on the .deb. It is rolling, not a fixed list -- the
+# first failure seen was python3-setuptools 52.0.0-4+deb11u2, the next run got
+# that one and 404ed on xz-utils instead -- and it is not transient, so the
+# workflow's five docker build retries all fail on it.
+#
+# The live mirror is still tried first, so this behaves exactly as before while it
+# is intact, and only on failure is the suite repointed at archive.debian.org,
 # which is frozen and complete. Check-Valid-Until is off because the archived
 # Release files are past their expiry date by design.
+#
+# bullseye-security is asked for but not required: the archive takes the security
+# suite some time after EOL and until then its Release file 404s, which makes apt
+# reject the whole update. So a failed update drops that line and retries against
+# the plain bullseye suite (the 11.11 point release), which carries every package
+# this image installs. The line starts working by itself once Debian archives the
+# suite -- nothing here needs revisiting for that.
 RUN set -eux; \
     PKGS="genisoimage git golang nodejs build-essential gcc-arm-none-eabi \
           python3-pip python3-distutils python3-setuptools curl xz-utils zip"; \
@@ -26,7 +36,15 @@ RUN set -eux; \
             [ -f "$f" ] || continue; \
             sed -i -E 's,https?://(deb|security)\.debian\.org/debian-security,http://archive.debian.org/debian-security,g; s,https?://deb\.debian\.org/debian,http://archive.debian.org/debian,g' "$f"; \
         done; \
-        apt-get update; \
+        apt-get update || { \
+            echo "archive.debian.org has no bullseye-security yet; dropping it" >&2; \
+            sed -i '/debian-security/d' /etc/apt/sources.list; \
+            for f in /etc/apt/sources.list.d/*.list; do \
+                [ -f "$f" ] || continue; \
+                sed -i '/debian-security/d' "$f"; \
+            done; \
+            apt-get update; \
+        }; \
         apt-get install -y $PKGS; \
     fi; \
     rm -rf /var/lib/apt/lists/*

--- a/.ci/toolchain.digest
+++ b/.ci/toolchain.digest
@@ -1,0 +1,2 @@
+image=ghcr.io/darthmotzkus/cubiboot-dev@sha256:f2529f5ee6d8f175966b00cb5727ca8f89ff21452eea4c94bb7d0f537bd71b6a
+dockerfile_sha256=56d4cc9c3fa0e94499e063043079f3033b2f51dd693df98be0351356c521e644

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -86,10 +86,32 @@ jobs:
           docker run --rm -v "$PWD":/work -e CUBIBOOT_VERSION="$STAMP" cubiboot-dev \
             bash -lc 'cd entry && make clean && make'
 
-          for f in cubeboot/cubeboot.dol patches/patches.elf entry/entry.dol; do
+          for f in cubeboot/cubeboot.dol patches/patches.elf; do
             cmp "/tmp/from-local/$(basename "$f")" "$f"
             echo "identical: $f ($(stat -c%s "$f") bytes)"
           done
+
+          # entry.dol is the one artefact that cannot come out byte-identical
+          # from two builds of the same tree, whatever image built it: it embeds
+          # data/cubeboot.gz, and entry/Makefile's gzip (no -n) records a
+          # timestamp in the gz header. Its payload is cubeboot.dol, compared
+          # byte for byte above, so what is checked here is that nothing besides
+          # that timestamp moved -- same size, and only those bytes differing,
+          # printed as offset/old/new so a real difference cannot hide among
+          # them.
+          local_size="$(stat -c%s /tmp/from-local/entry.dol)"
+          built_size="$(stat -c%s entry/entry.dol)"
+          if [ "$local_size" != "$built_size" ]; then
+            echo "entry.dol changed size: $local_size -> $built_size" >&2
+            exit 1
+          fi
+          cmp -l /tmp/from-local/entry.dol entry/entry.dol | head -16
+          diff_bytes="$(cmp -l /tmp/from-local/entry.dol entry/entry.dol | wc -l)"
+          if [ "$diff_bytes" -gt 4 ]; then
+            echo "entry.dol differs in $diff_bytes bytes, more than the 4-byte gz header timestamp" >&2
+            exit 1
+          fi
+          echo "entry.dol: $built_size bytes, $diff_bytes byte(s) differ (gz header timestamp only)"
 
           echo "image=$DIGEST" >> "$GITHUB_OUTPUT"
           echo "dockerfile_sha256=$(sha256sum .ci/Dockerfile | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Follow-up to #9. That PR prepared the switch to a prebuilt toolchain image but left it off; this one turns it on, after fixing two things the first *Toolchain image* runs on `main` exposed. With this merged, a push to the repo no longer touches any Debian mirror.

## `aa6a31b` — the round-trip check was wrong about `entry.dol`

The first run published fine and the two binaries that carry code came out byte-identical across the push/pull round trip — `cubeboot.dol` (731072 B) and `patches.elf` (449308 B) — but the check failed on `entry.dol` at byte 5861. That was the check, not the image: `entry.dol` embeds `data/cubeboot.gz`, and `entry/Makefile:121` gzips without `-n`, so the gz header carries a timestamp and two builds of the same tree can never match, whichever image built them.

`entry.dol` is now checked for what is invariant — same size, at most the 4 timestamp bytes differing, offsets printed so a real difference cannot hide among them. Its payload is `cubeboot.dol`, still compared byte for byte, so nothing is given up. Run 3 confirmed it: 1 byte differs, at offset 5861, the low byte of the timestamp.

The build is left alone deliberately. `gzip -n` would make `entry.dol` reproducible, but it changes the bytes of a shipped artefact (the gz header, which `tinfgzip` parses at boot) — not something to fold into a CI change without hardware validation. Worth its own decision.

## `c51fd6a` — `archive.debian.org` has no `bullseye-security` yet

Two findings from the second run. The purge is rolling: this time `python3-setuptools` (the first failure) fetched fine and `xz-utils_5.2.5-2.1~deb11u2` 404ed instead, so the live mirror cannot be trusted to recover. And the archive fallback fired correctly, got `bullseye` (InRelease + 8 MB `Packages`), then died on `bullseye-security`: the archive takes the security suite some time after EOL, and a missing `Release` makes apt reject the whole update.

The security line is now asked for but not required — a failed update drops it and retries against the plain `bullseye` suite (the 11.11 point release), which carries every package the image installs. Once Debian archives the suite, the line starts working by itself.

## `4b80c56` — the pin

Adopts the image *Toolchain image* run 3 published and verified. `dockerfile_sha256` matches `.ci/Dockerfile` at this commit (checked locally), so the pin is live rather than ignored.

## Verification

- *Toolchain image* [run 3](https://github.com/DarthMotzkus/cubiboot-new-ui/actions/runs/33919334507) on `c51fd6a`: green. Image built via the archive fallback, pushed, all local layers dropped, pulled back by digest, rebuilt: `cubeboot.dol` and `patches.elf` identical, `entry.dol` 1 byte (timestamp).
- CI [run 192](https://github.com/DarthMotzkus/cubiboot-new-ui/actions/runs/33919969002) on `4b80c56`: green through the pull path — `Login Succeeded`, `Pulling from darthmotzkus/cubiboot-dev`, `>> using prebuilt toolchain image …`; no apt, no Debian mirror anywhere in the log. Image step 48 s (was 1m38s–2m48s), whole job 1m07s. Artefacts as before.
- Locally: both apt paths and the `entry.dol` comparison exercised against stubs — a 20-byte difference and a size change both fail; identical and timestamp-only pass. Every `.ci/toolchain_image.sh` decision path re-run with the real digest file: it chooses the pull.

## Rollback

Delete `.ci/toolchain.digest` — every build goes back to assembling the image from `.ci/Dockerfile`, which still works (that is exactly what run 3 did).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dczt8oPHTTjqJdMwnEhEcc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dczt8oPHTTjqJdMwnEhEcc)_