### PR TITLE
ci: record which swiss-gc commit apploader.img embeds

### DIFF
--- a/.ci/build_apploader.sh
+++ b/.ci/build_apploader.sh
@@ -22,6 +22,14 @@ trap 'rm -rf "$WORK"' EXIT
 # 1) fetch only the swiss-gc packer
 git clone --depth 1 --filter=blob:none --sparse https://github.com/emukidid/swiss-gc.git "$WORK/swiss-gc"
 git -C "$WORK/swiss-gc" sparse-checkout set cube/packer
+# The checkout above is deliberately unpinned: the IGR stub has to follow Swiss.
+# The price is that two builds of the same cubiboot commit can embed different
+# stubs, so record which one this was -- in the log, and in a file beside the
+# output for ci.yml to put in the job summary and the release notes. It is what
+# makes an "In-Game Reset stopped working" report traceable to a Swiss commit.
+SWISS_COMMIT="$(git -C "$WORK/swiss-gc" rev-parse HEAD)"
+echo ">> swiss-gc packer at $SWISS_COMMIT (https://github.com/emukidid/swiss-gc/commit/$SWISS_COMMIT)"
+echo "$SWISS_COMMIT" > "$REPO/apploader.swiss-commit"
 
 # 2) payload = the cubeboot loader ELF (packer reads ../swiss/swiss.elf)
 mkdir -p "$WORK/swiss-gc/cube/swiss"

--- a/.ci/release-notes.md
+++ b/.ci/release-notes.md
@@ -13,6 +13,10 @@ headline and pushed the actual news below the fold. As a closing notice it stays
 without stealing the release.
 
 Only the "What's new" notes and the compare link get rewritten each release.
+
+The "**Build:**" line (swiss-gc commit behind apploader.img, toolchain image) is NOT in this
+file: ci.yml generates it at release time and inserts it just before the standing block.
+Do not add it by hand.
 -->
 
 ## What's new in v1.11.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,19 @@ jobs:
       - name: Build apploader.img
         run: docker run --rm -v "$PWD":/work cubiboot-dev bash -lc 'bash /work/.ci/build_apploader.sh'
 
+      # build_apploader.sh takes the Swiss packer from swiss-gc's HEAD on purpose
+      # (the IGR stub has to follow Swiss), so every build says which commit that
+      # was: here in the log and the job summary, and on a tag in the release notes
+      # below. A report of "In-Game Reset stopped working" then names a Swiss commit
+      # instead of a date.
+      - name: Record the swiss-gc commit behind apploader.img
+        run: |
+          set -e
+          SWISS="$(cat apploader.swiss-commit)"
+          echo "swiss-gc packer commit: $SWISS"
+          echo "SWISS_COMMIT=$SWISS" >> "$GITHUB_ENV"
+          echo "\`apploader.img\` embeds the swiss-gc packer at [\`${SWISS:0:7}\`](https://github.com/emukidid/swiss-gc/commit/$SWISS)." >> "$GITHUB_STEP_SUMMARY"
+
       # cubiboot.iso: bootable GameCube disc image for GC Loader (El-Torito ISO9660
       # built from cubeboot-tools' gbi.hdr re-branded to the Cubiboot banner + the
       # freshly built cubeboot loader .dol). Also writes cubiboot-noipl.iso (same disc,
@@ -132,11 +145,32 @@ jobs:
       # what actually changed under every "chore: refresh the banner artwork", and adds
       # contributor and PR lists nobody asked for. It also silently ignores the tag's own
       # annotation, so writing notes there does nothing.
+      # The body is .ci/release-notes.md plus one generated provenance line: the
+      # swiss-gc commit apploader.img embeds and the toolchain image that built
+      # everything. It goes in before the standing ">>" block, which that file
+      # requires to stay last; the file itself is not modified.
+      - name: Release notes with build provenance
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -e
+          LINE="**Build:** \`apploader.img\` embeds the swiss-gc packer at [\`${SWISS_COMMIT:0:7}\`](https://github.com/emukidid/swiss-gc/commit/$SWISS_COMMIT)"
+          IMAGE="$(sed -n 's/^image=//p' .ci/toolchain.digest 2>/dev/null || true)"
+          if [ -n "$IMAGE" ]; then
+            LINE="$LINE; built with toolchain image \`$(printf '%s' "${IMAGE#*@}" | cut -c1-19)\`"
+          fi
+          LINE="$LINE."
+          LINE="$LINE" awk '
+            !done && /^>>/ { print ENVIRON["LINE"]; print ""; done = 1 }
+            { print }
+            END { if (!done) { print ""; print ENVIRON["LINE"] } }
+          ' .ci/release-notes.md > release-body.md
+          echo "--- release body, last lines:"; tail -n 6 release-body.md
+
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          body_path: .ci/release-notes.md
+          body_path: release-body.md
           files: |
             dist/ipl.dol
             dist/flippydrive.dol

--- a/.github/workflows/rebuild-check.yml
+++ b/.github/workflows/rebuild-check.yml
@@ -130,9 +130,15 @@ jobs:
               printf '| `%s` | %s | %s | differs | size changed (%+d bytes) |\n' "$2" "$sa" "$sb" "$((sb - sa))"
             else
               local n first
-              n=$(cmp -l "$a" "$b" | wc -l)
-              first=$(cmp -l "$a" "$b" | head -6 | awk '{printf "%s ", $1}')
-              printf '| `%s` | %s | %s | differs | %s byte(s): offsets %s%s |\n' "$2" "$sa" "$sb" "$n" "$first" "$( [ "$n" -gt 6 ] && echo '…' )"
+              n=$(cmp -l "$a" "$b" 2>/dev/null | wc -l)
+              if [ "$n" -le 16 ]; then
+                # small enough to show in full: offset:release>other, values in octal as cmp prints them
+                first=$(cmp -l "$a" "$b" 2>/dev/null | awk '{printf "%s:%s>%s ", $1, $2, $3}')
+                printf '| `%s` | %s | %s | differs | %s byte(s), offset:old>new (octal): %s |\n' "$2" "$sa" "$sb" "$n" "$first"
+              else
+                first=$(cmp -l "$a" "$b" 2>/dev/null | head -6 | awk '{printf "%s ", $1}')
+                printf '| `%s` | %s | %s | differs | %s byte(s): offsets %s… |\n' "$2" "$sa" "$sb" "$n" "$first"
+              fi
             fi
           }
           table() { # $1 title  $2 dir

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,7 @@ patches/tests
 # entry/Makefile copies cubeboot/source/emu -> patches/source/emu at build time
 patches/source/emu/
 apploader.img
+apploader.swiss-commit
+release-body.md
 .localbuild/
 .claude/


### PR DESCRIPTION
CI-only. No source, no binary output changes: the build produces the same files plus one small text file (gitignored) and some log lines.

## Why

`build_apploader.sh` takes the Swiss packer from swiss-gc's HEAD on purpose: the In-Game Reset stub has to follow Swiss, so pinning it is not wanted. The price was that nothing recorded which Swiss went into a given `apploader.img`, so a report of "In-Game Reset stopped working" could only be dated, never traced to a Swiss commit.

## What changes

- `build_apploader.sh` prints the swiss-gc commit (linked) and writes it beside the output as `apploader.swiss-commit`.
- `ci.yml` puts that commit in the job summary on every build. On a tag it generates the release body from `.ci/release-notes.md` with one **Build:** line — the swiss-gc commit, linked, plus the toolchain image digest — inserted just before the standing `>>` block that file requires to stay last. The notes file itself is never modified; its header comment now says so.
- `rebuild-check.yml`: diffs of 16 bytes or fewer print `offset:old>new` values instead of offsets alone, so a handful of changed bytes can be identified from the summary. The `cmp | head` "Broken pipe" noise is gone.
- `.gitignore`: the two generated files.

## Verification

- CI [run 198](https://github.com/DarthMotzkus/cubiboot-new-ui/actions/runs/33938491361) on this branch: green; the new *Record the swiss-gc commit* step runs after the apploader build, all artefacts produced as before.
- The three workflows parse as YAML; every `run` block and `build_apploader.sh` pass `bash -n`.
- The release-body generation was dry-run against the real `.ci/release-notes.md`: 33 → 35 lines, the Build line lands immediately before the `>>` block, which stays last. The release step itself only runs on a tag, so its first real execution is the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dczt8oPHTTjqJdMwnEhEcc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dczt8oPHTTjqJdMwnEhEcc)_